### PR TITLE
Install node directly from nodesource

### DIFF
--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Add APT repository
   apt_repository:
-    repo: "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ distro }} main"
+    repo: "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
     update_cache: yes
 
 - name: Installing packages

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -13,14 +13,25 @@
 # limitations under the License.
 
 ---
-- name: Download node
-  get_url: 
-    url="{{ node_url }}"
-    dest="/tmp/{{ node_name }}.deb"
-  sudo: no
-  
-- name: Install node
-  apt: deb="/tmp/{{ node_name }}.deb"
-  
-- name: Install wscat
-  npm: name=wscat global=yes
+
+- name: Installing dependencies
+  apt:
+    pkg: apt-transport-https
+    state: present
+
+- name: Adding APT key
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+
+- name: Add APT repository
+  apt_repository:
+    repo: "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ distro }} main"
+    update_cache: yes
+
+- name: Installing packages
+  apt:
+    pkg: "{{ item }}"
+    state: present
+  with_items:
+    - nodejs
+    - build-essential

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -1,3 +1,2 @@
 ---
 nodejs_version: 5.x
-distro: jessie

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-node_name: node_latest_armhf
-node_url: http://node-arm.herokuapp.com/{{ node_name }}.deb
+nodejs_version: 5.x
+distro: jessie

--- a/site.yml
+++ b/site.yml
@@ -15,10 +15,10 @@
 ---
 # Run setup first, then this:
 # ansible-playbook -i hosts site.yml
-   
+
 - hosts: all
   remote_user: pi
-  gather_facts: no
+  gather_facts: yes
   sudo: yes
 
   roles:


### PR DESCRIPTION
No need to use node-arm.herokuapp.com, allows easier update with apt
later if needed.
