### PR TITLE
Resolve host via inventory (default) or ansible_ssh_host.

### DIFF
--- a/firstrun.sh
+++ b/firstrun.sh
@@ -23,4 +23,4 @@ if grep -q $HOST ~/.ssh/known_hosts; then
   ssh-keygen -R $HOST
 fi
 
-ansible-playbook -k -i $HOST, setup.yml -e "ssh_public_key=$PUBLIC_KEY" -e ansible_ssh_user=pi -e ansible_ssh_host=$HOST
+ansible-playbook -k -i $HOST, setup.yml -e "ssh_public_key=$PUBLIC_KEY" -e ansible_ssh_user=pi

--- a/handlers/handlers.yml
+++ b/handlers/handlers.yml
@@ -18,5 +18,5 @@
   notify: wait-for-reboot
 
 - name: wait-for-reboot
-  local_action: wait_for host={{ ansible_ssh_host }} port=22 state=started delay=10
+  local_action: wait_for host="{{ ansible_ssh_host | default(inventory_hostname) }}" port=22 search_regex=OpenSSH delay=10
   sudo: false

--- a/provision.sh
+++ b/provision.sh
@@ -16,4 +16,4 @@ if [ ! -f "$PLAYBOOK" ]; then
 fi
 
 export ANSIBLE_ROLES_PATH=$(dirname $0)/roles
-ansible-playbook -i $HOST, $PLAYBOOK -e ansible_ssh_host=$HOST
+ansible-playbook -i $HOST, $PLAYBOOK


### PR DESCRIPTION
Remove unnecessary env mapping from shell scripts .
