### PR TITLE
Signalk settings file

### DIFF
--- a/playbooks/chacal/freya.yml
+++ b/playbooks/chacal/freya.yml
@@ -40,6 +40,11 @@
       inadyn_ddns_username: "{{ chacal.inadyn_ddns_username }}"
       inadyn_ddns_password: "{{ chacal.inadyn_ddns_password }}"
       inadyn_ddns_hostname: "{{ chacal.inadyn_ddns_hostname.freya }}"
+    - role: signalk
+      signalk_settings_file: signalk-settings-freya.json
+      node_app_env:
+        - "NODE_ENV=production"
+        - "SIGNALK_NODE_SETTINGS=/etc/signalk-settings.json"
     - role: node-app
       node_app_name: "freya-server"
       node_app_git_repo: "https://github.com/chacal/freya-server.git"

--- a/playbooks/chacal/signalk-settings-freya.json
+++ b/playbooks/chacal/signalk-settings-freya.json
@@ -1,0 +1,27 @@
+{
+  "vessel": {
+    "name": "Freya",
+    "mmsi": "230061450"
+  },
+
+  "pipedProviders": [{
+    "id": "can0",
+    "pipeElements": [{
+      "type": "providers/execute",
+      "options": {
+        "command": "candump can0 | candump2analyzer | analyzer -json -si"
+      }
+    }, {
+      "type": "providers/liner"
+    }, {
+      "type": "providers/from_json"
+    }, {
+      "type": "providers/n2k-signalk"
+    }]
+  }],
+  "interfaces": {
+    "bower": true,
+    "rest": true,
+    "ws": true
+  }
+}

--- a/roles/signalk/tasks/main.yml
+++ b/roles/signalk/tasks/main.yml
@@ -19,3 +19,12 @@
     command: "npm install mdns"
     args:
       chdir: /opt/signalk-server
+
+  - name: Copy SignalK server settings
+    copy: src={{ signalk_settings_file }} dest=/etc/signalk-settings.json mode=0644
+    when: signalk_settings_file is defined
+    register: signalk_settings
+
+  - name: Restart SignalK server
+    service: name=signalk-server state=restarted
+    when: signalk_settings.changed


### PR DESCRIPTION
Optionally copy local SignalK settings file to `/etc/signalk-settings.json` from where it can be used by setting `SIGNALK_NODE_SETTINGS` environment variable. Restart SignalK server if the settings file changes.
