### PR TITLE
Added wrapper script support...

### DIFF
--- a/roles/node-app/defaults/main.yml
+++ b/roles/node-app/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 node_app_path: /opt/{{ node_app_name }}
+node_app_execstart: "/usr/bin/node {{ node_app_path }}/{{ node_app_main }}"
 node_app_user: "{{ ansible_ssh_user }}"
 node_app_group: "{{ ansible_ssh_user }}"
 node_app_port: 80

--- a/roles/node-app/tasks/main.yml
+++ b/roles/node-app/tasks/main.yml
@@ -9,6 +9,13 @@
 #    node_app_git_repo: "<url-to-application-git-repo>"
 #    node_app_main: "main.js"
 #
+# However, if a wrapper script is needed to start the app, the following can be used:
+#
+#  - role: node-app
+#    node_app_name: "my-application"
+#    node_app_git_repo: "<url-to-application-git-repo>"
+#    node_app_execstart: "<absolute/path/to/wrapper>"
+#
 # This role uses systemd to bind by default to port 80. You need to adjust
 # the application to listen to the systemd managed port:
 #  var SD_LISTEN_FDS_START = 3;

--- a/roles/node-app/templates/node_app_systemd_script.j2
+++ b/roles/node-app/templates/node_app_systemd_script.j2
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=/usr/bin/node {{ node_app_path }}/{{ node_app_main }}
+ExecStart={{ node_app_execstart }}
 Restart=always
 StandardOutput=syslog
 StandardError=syslog


### PR DESCRIPTION
...to running node apps under systemd. This would allow using node-app role to provision also apps that run node.js under some framework, like electron. 
