### PR TITLE
Remove canboat dependency

### DIFF
--- a/roles/signalk/meta/main.yml
+++ b/roles/signalk/meta/main.yml
@@ -21,5 +21,4 @@ dependencies:
       - "NODE_ENV=production"
       - "EXTERNALPORT=80"
       - "SIGNALK_NODE_SETTINGS=/etc/signalk-settings.json"
-
-  - role: canboat
+      


### PR DESCRIPTION
Obsolete due to introduction of canboatjs. Also, not needed by non-n2k users.