### PR TITLE
feature: install InfluxDB 1.5 from repo

### DIFF
--- a/roles/influxdb/defaults/main.yml
+++ b/roles/influxdb/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-influxdb_version: 1.3.2
+influxdb_version: 1.5

--- a/roles/influxdb/tasks/main.yml
+++ b/roles/influxdb/tasks/main.yml
@@ -13,56 +13,35 @@
 # limitations under the License.
 
 ---
-- name: Download InfluxDb binary distribution
-  get_url: url=https://dl.influxdata.com/influxdb/releases/influxdb-{{ influxdb_version }}_linux_armhf.tar.gz dest=/tmp/influxdb.tar.gz mode=0440
-  register: influxdb_package
-
-- name: Extract distribution package to /usr/local
-  shell: tar xf /tmp/influxdb.tar.gz -C / --strip-components=2 --no-same-owner
-  when: influxdb_package.changed
+- name: Add InfluxDb APT key
+  apt_key:
+    url: https://repos.influxdata.com/influxdb.key
   become: true
-  register: influxdb
+
+- name: Add InfluxDb APT repository
+  apt_repository:
+    repo: "deb https://repos.influxdata.com/debian  jessie main"
+    update_cache: yes
+  become: true
+
+- name: Install InfluxDb
+  apt: pkg=influxdb state=latest
+  become: true
 
 #1/10th or normal cache snaphot memory to ward off kernel killing influxdb
 - name: Custom configuration for RPi
   lineinfile: dest=/etc/influxdb/influxdb.conf line="  cache-snapshot-memory-size = 2621440" insertafter="  \# cache-snapshot-memory-size.*"
   become: true
 
-- name: HTTP API listen only on localhost
-  lineinfile:
-    dest: '/etc/influxdb/influxdb.conf'
-    line: '  bind-address = "localhost:8086"'
-    regexp: '  # bind-address = ":8086"'
-  become: true
-
-- name: Create Group
-  group: name=influxdb state=present
-  become: true
-
-- name: Create User infludb
-  user: name=influxdb group=influxdb state=present
-  become: true
-
-- name: Ensure directories with correct ownership
-  file: path={{ item }} state=directory owner=influxdb group=influxdb mode=0775
-  with_items:
-     - /var/lib/influxdb
-     - /etc/influxdb
-  become: true
-
-- name: Clear temporary files
-  file: path=/tmp/influxdb.tar.gz state=absent
-  when: influxdb.changed
-
-- name: Copy unit file
-  copy: remote_src=true src=/usr/lib/influxdb/scripts/influxdb.service dest=/lib/systemd/system/influxdb.service owner=root group=root force=yes
-  when: influxdb.changed
-  register: unit_file
-  become: true
+# - name: HTTP API listen only on localhost
+#   lineinfile:
+#     dest: '/etc/influxdb/influxdb.conf'
+#     line: '  bind-address = "localhost:8086"'
+#     regexp: '  # bind-address = ":8086"'
+#   become: true
 
 - name: Reload systemd
   command: systemctl daemon-reload
-  when: unit_file.changed
   become: true
 
 - name: Enable service and start it
@@ -70,5 +49,4 @@
   with_items:
   - systemctl enable influxdb
   - systemctl start influxdb
-  when: unit_file.changed
   become: true


### PR DESCRIPTION
Install InfluxDb from repo, manual download no longer
needed. Update version to 1.5. Localhost listening needs
to be checked, apparently not working as specified.