### PR TITLE
Better bridging support, takes also wlan peculiarities into account.

### DIFF
--- a/roles/nat_router/defaults/main.yml
+++ b/roles/nat_router/defaults/main.yml
@@ -25,14 +25,15 @@
 #        - eth0
 #        - wlan0
 #
-#  When using only bridged interfaces, one should set 
-#      nat_router_bridge_only: true
+#  One can also disable NATting and routing but still run networking
+#  and related services, like dnsmasq, by setting:
+#      nat_router_disable: true
 
 ---
 nat_router_local_interface: wlan0
 nat_router_inet_interface: eth0
 nat_router_bridge_interfaces: []
-nat_router_bridge_only: false
+nat_router_disable: false
 nat_router_ip: 192.168.74.1
 nat_router_netmask: 255.255.255.0
 nat_router_dhcp_range: "192.168.74.100,192.168.74.150,24h"

--- a/roles/nat_router/defaults/main.yml
+++ b/roles/nat_router/defaults/main.yml
@@ -17,10 +17,22 @@
 #       nat_router_fw_input_rules:
 #         - "-A INPUT -i {{ nat_router_inet_interface }} -s 192.168.8.1 -j ACCEPT"    # Allow traffic from Huawei HiLink modem's private interface
 #
+#  It is also possible to bridge interfaces, for example as follows:
+#    - role: nat_router
+#      nat_router_local_interface: br0
+#      nat_router_inet_interface: br0
+#      nat_router_bridge_interfaces: 
+#        - eth0
+#        - wlan0
 #
+#  When using only bridged interfaces, one should set 
+#      nat_router_bridge_only: true
+
 ---
 nat_router_local_interface: wlan0
 nat_router_inet_interface: eth0
+nat_router_bridge_interfaces: []
+nat_router_bridge_only: false
 nat_router_ip: 192.168.74.1
 nat_router_netmask: 255.255.255.0
 nat_router_dhcp_range: "192.168.74.100,192.168.74.150,24h"

--- a/roles/nat_router/handlers/main.yml
+++ b/roles/nat_router/handlers/main.yml
@@ -1,3 +1,9 @@
 ---
 - name: restart_dnsmasq
   service: name=dnsmasq state=restarted enabled=yes
+
+- name: restart_dhcpcd
+  service: name=dhcpcd state=restarted enabled=yes
+
+- name: restart_hostapd
+  service: name=hostapd state=restarted enabled=yes

--- a/roles/nat_router/tasks/main.yml
+++ b/roles/nat_router/tasks/main.yml
@@ -48,14 +48,14 @@
     line='source-directory /etc/network/interfaces.d'
   notify: restart-networking
 
-- name: Remove hotspot interface reference from the main interface file 
+- name: Remove local interface reference from the main interface file 
   replace:
     dest=/etc/network/interfaces
     regexp='^.*{{ nat_router_local_interface }}(.|\n)*?(\n|\Z)$'
     replace=''
   notify: restart-networking
 
-- name: Add separate file for hotspot to interface.d
+- name: Add separate file for local interface to interface.d directory
   template: src=interface.j2 dest=/etc/network/interfaces.d/{{ nat_router_local_interface }}_hotspot  # NOTE: filename must match ^[a-zA-Z0-9_-]+$ (no '.' allowed!)
   notify: restart-networking
 
@@ -75,7 +75,7 @@
 
 - name: Enable IPv4 forwarding
   lineinfile: dest=/etc/sysctl.conf regexp='.*net.ipv4.ip_forward.*' line='net.ipv4.ip_forward=1'
-  when: nat_router_bridge_only == false
+  when: nat_router_disable == false
   notify: reload_sysctl
 
 # Run handlers to get all network interfaces up before applying firewall configuration
@@ -84,8 +84,8 @@
 - name: iptables config file
   template: src=iptables_conf.j2 dest=/etc/iptables.ipv4.nat
   register: iptables_config
-  when: nat_router_bridge_only == false
+  when: nat_router_disable == false
 
 - name: Import iptables config
   shell: iptables-restore < /etc/iptables.ipv4.nat
-  when: iptables_config.changed and nat_router_bridge_only == false
+  when: iptables_config.changed and nat_router_disable == false

--- a/roles/nat_router/tasks/main.yml
+++ b/roles/nat_router/tasks/main.yml
@@ -59,14 +59,23 @@
   template: src=interface.j2 dest=/etc/network/interfaces.d/{{ nat_router_local_interface }}_hotspot  # NOTE: filename must match ^[a-zA-Z0-9_-]+$ (no '.' allowed!)
   notify: restart-networking
 
+- name: add bridge to hostapd.conf # Note: Hotspot role should be run first!
+  lineinfile: 
+    dest=/etc/hostapd/hostapd.conf 
+    line='bridge=br0'
+  when: nat_router_bridge_interfaces|join(" ") is search("wlan")
+  notify: restart_hostapd
+
 - name: Disable DHCP client on local interface
   lineinfile: dest=/etc/dhcpcd.conf regexp='^denyinterfaces .*' line='denyinterfaces {{ nat_router_local_interface }}'
+  notify: restart_dhcpcd
 
 ##############################################################################
 # Routing and NATting
 
 - name: Enable IPv4 forwarding
   lineinfile: dest=/etc/sysctl.conf regexp='.*net.ipv4.ip_forward.*' line='net.ipv4.ip_forward=1'
+  when: nat_router_bridge_only == false
   notify: reload_sysctl
 
 # Run handlers to get all network interfaces up before applying firewall configuration
@@ -75,7 +84,8 @@
 - name: iptables config file
   template: src=iptables_conf.j2 dest=/etc/iptables.ipv4.nat
   register: iptables_config
+  when: nat_router_bridge_only == false
 
 - name: Import iptables config
   shell: iptables-restore < /etc/iptables.ipv4.nat
-  when: iptables_config.changed
+  when: iptables_config.changed and nat_router_bridge_only == false

--- a/roles/nat_router/templates/interface.j2
+++ b/roles/nat_router/templates/interface.j2
@@ -1,14 +1,23 @@
-# Hotspot
+{% for interface in nat_router_bridge_interfaces %}
+{% if "wlan" in interface %}
+allow-hotplug {{ interface }}
+{% else %}
+auto {{ interface }}
+{% endif %}
+iface {{ interface }} inet manual
 
+{% endfor %}
 auto {{ nat_router_local_interface }}
 allow-hotplug {{ nat_router_local_interface }}
 iface {{ nat_router_local_interface }} inet static
 {% if nat_router_bridge_interfaces is defined %}
-  bridge_ports {{ nat_router_bridge_interfaces }}
+  bridge_ports {{ nat_router_bridge_interfaces|join(" ") }}
 {% endif %}
   address {{ nat_router_ip }}
   netmask {{ nat_router_netmask }}
 {% if nat_router_gateway is defined %}
   gateway {{ nat_router_gateway }}
 {% endif %}
+{% if nat_router_bridge_only == false %}
   post-up if [ -f /etc/iptables.ipv4.nat ]; then iptables-restore < /etc/iptables.ipv4.nat; fi
+{% endif %}

--- a/roles/nat_router/templates/interface.j2
+++ b/roles/nat_router/templates/interface.j2
@@ -18,6 +18,6 @@ iface {{ nat_router_local_interface }} inet static
 {% if nat_router_gateway is defined %}
   gateway {{ nat_router_gateway }}
 {% endif %}
-{% if nat_router_bridge_only == false %}
+{% if nat_router_disable == false %}
   post-up if [ -f /etc/iptables.ipv4.nat ]; then iptables-restore < /etc/iptables.ipv4.nat; fi
 {% endif %}


### PR DESCRIPTION
Option for bridge-only mode, essentially skipping NAT and routing. ;)
Not backward-compatible as nat_router_bridge_interfaces is changed from a string to a list.