### PR TITLE
fix: remove server webapps' builds

### DIFF
--- a/roles/signalk/tasks/main.yml
+++ b/roles/signalk/tasks/main.yml
@@ -45,11 +45,6 @@
     with_items: "{{ signalk_plugins }}"
     when: signalk_plugins is defined
 
-  - name: build admin-ui and plugin-config
-    command: "npm run prepublishOnly"
-    args:
-      chdir: /opt/signalk-server
-
   - name: Restart SignalK server
     service: name=signalk-server state=restarted
     when: signalk_settings.changed


### PR DESCRIPTION
We switched to installing the server admin & plugin config ui
from the npm, so the builds are no longer needed nor where they
used to be.