### PR TITLE
Armv6 node upgrade support

### DIFF
--- a/provision-single-role.sh
+++ b/provision-single-role.sh
@@ -8,9 +8,13 @@ shift 1
 cat > /tmp/play.yml <<PLAYBOOK
 ---
 - hosts: all
+  remote_user: pi
+  gather_facts: yes
+  become: yes
+
   roles:
   - $role
 PLAYBOOK
 
 export ANSIBLE_ROLES_PATH=$(dirname $0)/roles
-ansible-playbook /tmp/play.yml -i $1, -u pi
+ansible-playbook /tmp/play.yml -i $1,

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
-# For ARMv6 models (A, A+, B, B+). This should match a directory name on the download site: https://nodejs.org/dist/ (e.g. latest-v4.x, v5.8.0, latest)
-nodejs_armv6_version: latest-boron   # Latest 6.x series LTS release
+# For ARMv6 models (A, A+, B, B+, Zero, Zero W). This should match a directory name on the download site: https://nodejs.org/dist/ (e.g. latest-v4.x, v5.8.0, latest)
+nodejs_armv6_version: latest-v10.x   # Latest 10.x series LTS release
+# The path to the binary of ARMv6 node installation
+nodejs_armv6_binary: /usr/local/bin/node
 
 # For ARMv7 models (>= 2). This should match NodeSource's versioning (e.g. 4.x, 5.x or 4.4.0)
 nodejs_armv7_version: 10.x

--- a/roles/node/tasks/armv6_from_nodejs_org.yml
+++ b/roles/node/tasks/armv6_from_nodejs_org.yml
@@ -14,28 +14,46 @@
 
 ---
 
-# Greps & seds the package name part from the directory listing page, result is like 'node-v4.4.1-linux-armv6l'
-# Changes only if Node has not been installed at all (= doesn't do updates at least for now..)
-- name: Get download package name
-  shell: curl https://nodejs.org/dist/{{ nodejs_armv6_version }}/ | grep armv6l.tar.gz | sed 's/.*>\(node-.*\).tar.gz<\/a>.*/\1/g' creates=/usr/local/bin/node
-  register: node_package
+- name: Check for existing Node.js install
+  stat:
+    path: "{{ nodejs_armv6_binary }}"
+  register: node_exists
 
-- name: Generate download url
-  set_fact: node_download_url=https://nodejs.org/dist/{{ nodejs_armv6_version }}/{{ node_package.stdout }}.tar.gz
-  when: node_package.changed
+- name: Get installed Node.js version
+  command: "{{ nodejs_armv6_binary }} --version"
+  register: installed_node_version
+  when: "node_exists.stat.exists"
+  changed_when: False
+  failed_when: False
 
-- name: Download Node.js binary distribution
-  get_url: url={{ node_download_url }} dest=/tmp/nodejs.tar.gz mode=0440
-  when: node_package.changed
+- name: Get latest available Node.js tarball filename
+  shell: curl https://nodejs.org/dist/{{ nodejs_armv6_version }}/ | grep armv6l.tar.gz | sed 's/.*>\(.*\)<\/a>.*/\1/g'
+  args:
+    warn: False
+  register: latest_node_filename
+  changed_when: False
 
-- name: Extract distribution package to /usr/local
-  shell: tar xzf /tmp/nodejs.tar.gz -C /usr/local --strip-components=1 --no-same-owner
-  when: node_package.changed
+- name: Get latest available Node.js version
+  set_fact:
+    latest_node_version: "{{ latest_node_filename.stdout | regex_search('node-(.*)-linux-armv6l.tar.gz', '\\1') | first }}"
 
-- name: Link binary to /usr/bin/node
-  file: src=/usr/local/bin/node dest=/usr/bin/node state=link force=yes
-  when: node_package.changed
+- name: Install Node.js
+  block:
+  - name: Generate download URL
+    set_fact: node_download_url=https://nodejs.org/dist/{{ nodejs_armv6_version }}/node-{{ latest_node_version }}-linux-armv6l.tar.gz
 
-- name: Clear temporary files
-  file: path=/tmp/nodejs.tar.gz state=absent
-  when: node_package.changed
+  - name: Download Node.js binary distribution
+    get_url: url={{ node_download_url }} dest=/tmp/nodejs.tar.gz mode=0440
+
+  - name: Extract distribution package to /usr/local
+    shell: tar xzf /tmp/nodejs.tar.gz -C /usr/local --strip-components=1 --no-same-owner
+    args:
+      warn: False
+
+  - name: Link binary to /usr/bin/node
+    file: src=/usr/local/bin/node dest=/usr/bin/node state=link force=yes
+
+  - name: Clear temporary files
+    file: path=/tmp/nodejs.tar.gz state=absent
+
+  when: (not node_exists.stat.exists) or (latest_node_version != installed_node_version.stdout)

--- a/roles/node/tasks/armv6_from_nodejs_org.yml
+++ b/roles/node/tasks/armv6_from_nodejs_org.yml
@@ -27,7 +27,7 @@
   failed_when: False
 
 - name: Get latest available Node.js tarball filename
-  shell: curl https://nodejs.org/dist/{{ nodejs_armv6_version }}/ | grep armv6l.tar.gz | sed 's/.*>\(.*\)<\/a>.*/\1/g'
+  shell: curl https://nodejs.org/dist/{{ nodejs_armv6_version }}/ | grep armv6l.tar.gz | sed 's/.*>\(.*\)<\/a>.*/\1/g' || /bin/true
   args:
     warn: False
   register: latest_node_filename
@@ -36,6 +36,7 @@
 - name: Get latest available Node.js version
   set_fact:
     latest_node_version: "{{ latest_node_filename.stdout | regex_search('node-(.*)-linux-armv6l.tar.gz', '\\1') | first }}"
+  when: latest_node_filename.stdout != ""
 
 - name: Install Node.js
   block:
@@ -56,4 +57,5 @@
   - name: Clear temporary files
     file: path=/tmp/nodejs.tar.gz state=absent
 
-  when: (not node_exists.stat.exists) or (latest_node_version != installed_node_version.stdout)
+  when: (not node_exists.stat.exists)
+        or (latest_node_version is defined and (latest_node_version != installed_node_version.stdout))


### PR DESCRIPTION
I'm stuck to armv6 on the Raspberry Pi Zero W. This PR adds support to conditionally upgrading the installed Node.js version (and bumps the Node.js version from 6.x to 10.x...).