### PR TITLE
Support specifying SK git branch

### DIFF
--- a/example-boat.yml
+++ b/example-boat.yml
@@ -31,6 +31,14 @@
     #
     #- timezone: Europe/Helsinki
 
+    # SignalK node server git branch (optional)
+    #
+    #  Defaults to 'latest', referring to the latest released version.
+    #  Other interesting options would be 'master', referring to the
+    #  latest development version, or (say) 'v1.9.1', referring to a
+    #  specific released version.
+    #- signalk_server_git_branch: latest
+
     # signalk_settings_file - config file for server (optional)
     #
     #  defaults to the testing config file. Uncomment to override. for

--- a/example-boat.yml
+++ b/example-boat.yml
@@ -31,13 +31,13 @@
     #
     #- timezone: Europe/Helsinki
 
-    # signalk_setings_file - config file for server (optional)
+    # signalk_settings_file - config file for server (optional)
     #
     #  defaults to the testing config file. Uncomment to override. for
     #  examples see:
     #    https://github.com/SignalK/signalk-server-node/tree/master/settings
     #
-    #- signalk_setings_file: ./settings.json
+    #- signalk_settings_file: ./settings.json
 
     - wificlient_networks:
        - ssid: <your marina ssid 1 here>

--- a/roles/node-app/defaults/main.yml
+++ b/roles/node-app/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 node_app_path: /opt/{{ node_app_name }}
+node_app_git_branch: master
 node_app_user: pi
 node_app_group: pi
 node_app_use_socket: true

--- a/roles/node-app/tasks/main.yml
+++ b/roles/node-app/tasks/main.yml
@@ -30,7 +30,7 @@
   file: path={{ node_app_path }} state=directory mode=0755 owner={{ node_app_user }} group={{ node_app_group }}
 
 - name: "{{ node_app_name }} | Pull sources from the repository"
-  git: repo={{ node_app_git_repo }} dest={{ node_app_path }} force=yes version=master
+  git: repo={{ node_app_git_repo }} dest={{ node_app_path }} force=yes version={{ node_app_git_branch }}
   become_user: "{{ node_app_user }}"
   register: git_pull
 

--- a/roles/signalk/meta/main.yml
+++ b/roles/signalk/meta/main.yml
@@ -16,9 +16,9 @@ dependencies:
   - role: node-app
     node_app_name: "signalk-server"
     node_app_git_repo: "https://github.com/SignalK/signalk-server-node.git"
+    node_app_git_branch: "{{ signalk_server_git_branch | default('latest') }}"
     node_app_main: "bin/signalk-server"
     node_app_env:
       - "NODE_ENV=production"
       - "EXTERNALPORT=80"
       - "SIGNALK_NODE_SETTINGS=/etc/signalk-settings.json"
-      


### PR DESCRIPTION
I'd rather use the latest released SK server version instead of master. This PR adds support for specifying a git branch/tag to use.

Note: default semantics are changed. Previously, master was always used. Now, "latest" is the default. I believe that's a safer default for non-developers.