### PR TITLE
Timezone setting

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -21,13 +21,9 @@
 - name: New hostname also to /etc/hosts file
   lineinfile: dest=/etc/hosts regexp='^127\.0\.1\.1' line='127.0.1.1 {{ hostname }}'
 
-- name: Copy timezone file
-  template: src=timezone.j2 dest=/etc/timezone mode=0644
-  register: timezone_result
-
 - name: Set timezone
-  command: dpkg-reconfigure -f noninteractive tzdata
-  when: timezone_result.changed
+  timezone:
+    name: "{{ timezone }}"
 
 - name: Update the apt cache
   apt: update_cache=yes cache_valid_time=7200

--- a/roles/common/templates/timezone.j2
+++ b/roles/common/templates/timezone.j2
@@ -1,1 +1,0 @@
-{{ timezone }}


### PR DESCRIPTION
Timezone setting wasn't idempotent (or at least always reported as "changed"). And worse, it didn't work for me - the dpkg-reconfigure call always reset my TZ to Europe/London.

Now, the provided ansible module is used instead.