### PR TITLE
Perform CAN interface setup via network config files

### DIFF
--- a/example-boat.yml
+++ b/example-boat.yml
@@ -69,6 +69,13 @@
     - canboat
     - signalk
     - pysk
+    #- role: mcp2515-can
+    #  mcp2515_can_device: can0
+    #  mcp2515_oscillator_freq: 8000000
+    #  mcp2515_int_pin: 12
+    #  mcp2515_bitrate: 250000
+    #  mcp2515_tx_queuelen: 100
+
 
   handlers:
     - include: handlers/handlers.yml

--- a/roles/mcp2515-can/tasks/main.yml
+++ b/roles/mcp2515-can/tasks/main.yml
@@ -6,20 +6,11 @@
     line="dtoverlay=mcp2515-{{ mcp2515_can_device }},oscillator={{ mcp2515_oscillator_freq }},interrupt={{ mcp2515_int_pin }}"
   notify: reboot
 
-- name: Bring up CAN device on boot
-  lineinfile:
-    dest: /etc/rc.local
-    regexp: '^ip link set {{ mcp2515_can_device }} up type can bitrate'
-    line: "ip link set {{ mcp2515_can_device }} up type can bitrate {{ mcp2515_bitrate }} || true"
-    insertbefore: "^exit 0$"
-  notify: reboot
-
-- name: Set CAN device tx queue length on boot
-  lineinfile:
-    dest: /etc/rc.local
-    regexp: '^ip link set {{ mcp2515_can_device }} txqueuelen'
-    line: "ip link set {{ mcp2515_can_device }} txqueuelen {{ mcp2515_tx_queuelen }}  || true"
-    insertafter: "^ip link set {{ mcp2515_can_device }} up"
+- name: Setup a CAN device
+  template:
+    src: can.j2
+    dest: /etc/network/interfaces.d/{{ mcp2515_can_device }}
+    mode: '0644'
   notify: reboot
 
 - name: Install can-utils

--- a/roles/mcp2515-can/templates/can.j2
+++ b/roles/mcp2515-can/templates/can.j2
@@ -1,0 +1,4 @@
+auto {{ mcp2515_can_device }}
+iface {{ mcp2515_can_device }} can static
+        bitrate {{ mcp2515_bitrate }}
+        up /sbin/ifconfig {{ mcp2515_can_device }} txqueuelen {{ mcp2515_tx_queuelen }}


### PR DESCRIPTION
Better have the CAN interface set up using /etc/network/interfaces.d instead of rc.local scripting.