### PR TITLE
Remove manual npm installing

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -27,6 +27,7 @@
 
 - name: Update the apt cache
   apt: update_cache=yes cache_valid_time=7200
+  failed_when: False
 
 - name: Update the Raspbian distribution
   apt: upgrade=yes

--- a/roles/hotspot/tasks/main.yml
+++ b/roles/hotspot/tasks/main.yml
@@ -31,7 +31,7 @@
   notify: restart_hostapd
 
 - name: Point hostapd at the config file
-  lineinfile: dest=/etc/default/hostapd regexp=^'DAEMON_CONF=' line='DAEMON_CONF="/etc/hostapd/hostapd.conf"'
+  lineinfile: dest=/etc/default/hostapd regexp='^DAEMON_CONF=' line='DAEMON_CONF="/etc/hostapd/hostapd.conf"'
   notify: restart_hostapd
 
 # Reboot due to possible changes now

--- a/roles/signalk/tasks/main.yml
+++ b/roles/signalk/tasks/main.yml
@@ -15,18 +15,6 @@
   - name: "Install mdns dependency"
     apt: pkg=libavahi-compat-libdnssd-dev state=latest
 
-  - name: "Install mdns for Signal K server"
-    become: no
-    npm:
-      name: mdns
-      path: /opt/signalk-server
-
-  - name: "Install socketcan for Signal K server"
-    become: no
-    npm:
-      name: socketcan
-      path: /opt/signalk-server
-
   - name: Copy Default SignalK server settings
     copy:
       src: /opt/signalk-server/settings/settings.json


### PR DESCRIPTION
Don't install socketcan and mdns NPM packages manually - they're pulled in automatically, and manual installation litters `package.json`, causing the playbook to always reinstall signalk-server.

Also assorted random fixes.