### PR TITLE
Pi-super-UPS support

### DIFF
--- a/roles/pi-super-ups/defaults/main.yml
+++ b/roles/pi-super-ups/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+pi_super_ups_sense_pin: 26
+pi_super_ups_hold_time: 1.0
+pi_super_up_watchdog_pin: 21
+pi_super_ups_directory: pi_super_ups

--- a/roles/pi-super-ups/tasks/main.yml
+++ b/roles/pi-super-ups/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: Install python setuptools
+  apt:
+    name: "{{ packages }}"
+    state: latest
+  vars:
+    packages:
+      - python3-setuptools
+      - python3-dev
+
+- name: Download pi-super-ups
+  git: repo=https://github.com/mairas/pi-super-ups.git dest={{pi_super_ups_directory}} clone=yes force=yes
+  become: no
+  register: pi_super_ups_sources
+
+- name: Install pi-super-ups
+  command: python3 setup.py install
+  args:
+    chdir: "{{pi_super_ups_directory}}/src"
+  when: pi_super_ups_sources.changed
+
+- name: Setup the pi-super-ups systemd service
+  template: src=pi_super_ups_systemd_script.j2 dest=/lib/systemd/system/pi_super_ups.service owner=root group=root mode=0644
+  register: unit_file
+
+- name: "pi_super_ups | Reload systemd"
+  command: systemctl daemon-reload
+  when: unit_file.changed
+
+- name: "pi_super_ups | Restart application"
+  service: name=pi_super_ups state=restarted enabled=yes
+  when: pi_super_ups_sources.changed or unit_file.changed

--- a/roles/pi-super-ups/templates/pi_super_ups_systemd_script.j2
+++ b/roles/pi-super-ups/templates/pi_super_ups_systemd_script.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Pi Super UPS
+After=syslog.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+User=pi
+ExecStart=/usr/local/bin/pi-super-ups --sense-pin {{ pi_super_ups_sense_pin }} --hold-time {{ pi_super_ups_hold_time }} --watchdog-pin {{ pi_super_up_watchdog_pin }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/rtc/tasks/main.yml
+++ b/roles/rtc/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Enable RTC
+  lineinfile:
+    dest: /boot/config.txt
+    regexp: '^#(dtoverlay=i2c-rtc,ds3231)$'
+    line: '\1'
+    backrefs: yes
+  notify: reboot
+
+- name: modify /lib/udev/hwclock-set
+  command: sed --in-place='' -e '/systemd/,+2 s/^/#/' /lib/udev/hwclock-set

--- a/roles/signalk/tasks/main.yml
+++ b/roles/signalk/tasks/main.yml
@@ -28,7 +28,7 @@
   - name: Copy Custom SignalK server settings
     copy:
       src: '{{ signalk_settings_file }}'
-      dest: /etc/signalk-settings.json
+      dest: /home/pi/.signalk/defaults.json
       mode: 0644
       owner: "{{ ansible_user }}"
     when: signalk_settings_file is defined


### PR DESCRIPTION
A role to enable the pi-super-ups daemon. Another to enable the DS3231 RTC module. And a commit to fix the config file location (at least I don't think the current setup reads it from `/etc`).