### PR TITLE
Add /dev/serial/by-id

### DIFF
--- a/roles/signalk-docker/templates/docker-compose.j2
+++ b/roles/signalk-docker/templates/docker-compose.j2
@@ -19,6 +19,7 @@ services:
     volumes:
      - "/home/pi/.signalk:/home/signalk/.signalk"
      - "/home/pi/signalk-docker-data/logs:/signalk-log"
+     - "/dev/serial:/dev/serial"
     restart: always
     privileged: true
   influxdb:


### PR DESCRIPTION
Add access to /dev/serial/by-id so that you can use the
symlinks there to create persistent links to devices in
Signal K configuration.