### PR TITLE
Fix Docker systemd service start/stop order

### DIFF
--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: "Reload systemd"
+  systemd:
+    daemon_reload: yes

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -18,6 +18,15 @@
     path: /tmp/docker-install.sh
     state: absent
 
+# Fix Docker bug: add containerd as pre-requisite for Docker service, see: https://github.com/docker/for-linux/issues/421
+- name: Start Docker after containerd
+  lineinfile:
+    dest: /lib/systemd/system/docker.service
+    regexp: "^After="
+    line: "After=network-online.target firewalld.service containerd.service"
+  notify: Reload systemd
+  become: true
+
 - name: Set Docker to auto-start
   service:
     name: docker


### PR DESCRIPTION
Docker should start after containerd and stop before it. See: https://github.com/docker/for-linux/issues/421 Without fix shutting down Raspi takes many minutes and reboot fails completely.