### PR TITLE
Use async as installs may timeout on slow SD cards

### DIFF
--- a/roles/node-app/tasks/main.yml
+++ b/roles/node-app/tasks/main.yml
@@ -38,6 +38,8 @@
   shell: chdir={{ node_app_path }} npm install{{ ' --unsafe-perm' if node_app_npm_unsafe_perm else '' }}
   become_user: "{{ node_app_user }}"
   when: git_pull.changed
+  async: 3600
+  poll: 10
 
 - name: "{{ node_app_name }} | Install systemd unit file"
   template: src=node_app_systemd_script.j2 dest=/lib/systemd/system/{{ node_app_name }}.service owner=root group=root mode=0644

--- a/roles/signalk/tasks/install_plugin.yml
+++ b/roles/signalk/tasks/install_plugin.yml
@@ -12,6 +12,8 @@
     name: "{{ plugin_name }}"
     path: "/home/{{ node_app_user }}/.signalk/"
     production: yes
+  async: 3600
+  poll: 10
   become_user: "{{ node_app_user }}"
   when: plugin_name is defined
   notify: restart-signalk-server


### PR DESCRIPTION
I've seen Signal K or plugin NPM install fail with an Ansible timeout. Using the async setting should make provisioning more robust.