### PR TITLE
Use the latest-release branch

### DIFF
--- a/roles/signalk/meta/main.yml
+++ b/roles/signalk/meta/main.yml
@@ -16,7 +16,7 @@ dependencies:
   - role: node-app
     node_app_name: "signalk-server"
     node_app_git_repo: "https://github.com/SignalK/signalk-server-node.git"
-    node_app_git_branch: "{{ signalk_server_git_branch | default('latest') }}"
+    node_app_git_branch: "{{ signalk_server_git_branch | default('latest-release') }}"
     node_app_main: "bin/signalk-server"
     node_app_env:
       - "NODE_ENV=production"


### PR DESCRIPTION
signalk-node-server no longer has a `latest` branch