### PR TITLE
Use Ansible reboot module

### DIFF
--- a/handlers/handlers.yml
+++ b/handlers/handlers.yml
@@ -14,12 +14,12 @@
 - name: reload_sysctl
   shell: "sysctl -p"
 
-# Keep these at the end to run the reboot handler after all other handlers
+# Keep this at the end to run the reboot handler after all other handlers
 - name: reboot
-  shell: shutdown -r now &
-  ignore_errors: true
-  notify: wait-for-reboot
-
-- name: wait-for-reboot
-  local_action: wait_for host="{{ inventory_hostname }}" port=22 search_regex=OpenSSH delay=10
-  become: false
+  reboot:
+    msg: "Reboot initiated by Ansible"
+    connect_timeout: 5
+    reboot_timeout: 120
+    pre_reboot_delay: 0
+    post_reboot_delay: 30
+    test_command: whoami  


### PR DESCRIPTION
instead of shell command and local trickery. Work nicely on my test runs (against RPi3B+ and Buster Lite) once specified a tangible  post_reboot_delay.

https://docs.ansible.com/ansible/latest/modules/reboot_module.html
https://www.ansible.com/blog/reboot-plugin-for-linux-in-ansible-2-7
