### PR TITLE
Allow separately setting the overlay interface for MCP2515 kernel module

### DIFF
--- a/roles/mcp2515-can/defaults/main.yml
+++ b/roles/mcp2515-can/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
-mcp2515_can_device: can0
+mcp2515_can_device: can0          # Used CAN network device name, with one CAN interface always can0
+mcp2515_overlay_can_device: can0  # Used overlay device, can0 == spidev0.0 (SPI_CE0 pin), can1 == spidev0.1 (SPI_CE1 pin)
 mcp2515_oscillator_freq: 8000000  # 8MHz by default, this must match the crystal on the MCP2515 module
 mcp2515_int_pin: 22               # GPIO pin number to which the MCP module's interrupt pin is connected
 mcp2515_bitrate: 250000           # NMEA2000 bus operates at 250kbps

--- a/roles/mcp2515-can/tasks/main.yml
+++ b/roles/mcp2515-can/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: Setup MCP2515 can device
   lineinfile:
     dest=/boot/config.txt
-    regexp='^dtoverlay=mcp2515-{{ mcp2515_can_device }}'
-    line="dtoverlay=mcp2515-{{ mcp2515_can_device }},oscillator={{ mcp2515_oscillator_freq }},interrupt={{ mcp2515_int_pin }}"
+    regexp='^dtoverlay=mcp2515-{{ mcp2515_overlay_can_device }}'
+    line="dtoverlay=mcp2515-{{ mcp2515_overlay_can_device }},oscillator={{ mcp2515_oscillator_freq }},interrupt={{ mcp2515_int_pin }}"
   notify: reboot
 
 - name: Setup a CAN device


### PR DESCRIPTION
This is needed if MCP2515 is connected to spidev0.1 and spidev0.0 is used for some other SPI device. In this case mcp2515_overlay_can_device must be set to can1 or otherwise the MCP2515 kernel module uses spidev0.0. The network interface will still be can0 as there will only be one CAN interface in the system.