### PR TITLE
Fix signalk-docker user

### DIFF
--- a/roles/signalk-docker/tasks/main.yml
+++ b/roles/signalk-docker/tasks/main.yml
@@ -1,22 +1,3 @@
-
-- name: signalk group
-  group:
-    name: signalk
-    state: present
-
-- name: Add pi to signalk group
-  user:
-    name: pi
-    groups: signalk
-    append: yes
-
-- name: Add signalk service user
-  user:
-    name: signalk
-    comment: Signal K service account
-    uid: "999"
-    group: signalk
-
 - name: Create service
   file:
     path: /etc/signalk-docker-compose
@@ -38,8 +19,7 @@
     path: "{{ item }}"
     state: directory
     mode: "06770"
-    owner: signalk
-    group: signalk
+    owner: pi
   with_items:
     - /home/pi/signalk-docker-data
     - /home/pi/signalk-docker-data/logs
@@ -52,31 +32,27 @@
   template:
     src: plugin-package.json
     dest: /home/pi/.signalk/package.json
-    owner: signalk
-    group: signalk
+    owner: pi
 
 - name: settings.json
   template:
     src: settings.json
     dest: /home/pi/.signalk/settings.json
-    owner: signalk
-    group: signalk
+    owner: pi
     force: no
 
 - name: settings.json
   template:
     src: signalk-to-influxdb.json
     dest: /home/pi/.signalk/plugin-config-data/signalk-to-influxdb.json
-    owner: signalk
-    group: signalk
+    owner: pi
     force: no
 
 - name: datasource
   template:
     src: datasource.yml
     dest: /home/pi/signalk-docker-data/grafana/provisioning/datasources/datasource.yaml
-    owner: signalk
-    group: signalk
+    owner: pi
 
 - name: Install plugins
   command: docker run -it --rm -v /home/pi/.signalk:/home/signalk/.signalk --entrypoint "/bin/bash" signalk/signalk-server:linux-armhf-latest -c "cd /home/signalk/.signalk && npm install"

--- a/roles/signalk-docker/templates/docker-compose.j2
+++ b/roles/signalk-docker/templates/docker-compose.j2
@@ -17,7 +17,7 @@ services:
       - "9998:9998"
       - "9999:9999"
     volumes:
-      - "/home/pi/.signalk:/home/signalk/.signalk"
+      - "/home/pi/.signalk:/home/node/.signalk"
       - "/home/pi/signalk-docker-data/logs:/signalk-log"
       - "/dev/serial:/dev/serial"
     restart: always
@@ -30,7 +30,7 @@ services:
     volumes:
       - "/home/pi/signalk-docker-data/influxdb:/var/lib/influxdb"
     restart: always
-    user: "999"
+    user: "1000"
   grafana:
     image: "grafana/grafana"
     environment:
@@ -40,5 +40,5 @@ services:
     volumes:
       - "/home/pi/signalk-docker-data/grafana:/var/lib/grafana"
       - "/home/pi/signalk-docker-data/grafana/provisioning:/etc/grafana/provisioning/"
-    user: "999"
     restart: always
+    user: "1000"


### PR DESCRIPTION
SK Server Docker image runs nowadays as user 1000 node, that lines up
with Raspbian default user 1000 pi, so the extra user is no longer needed.