### PR TITLE
Optionally delay unattended upgrade reboot until some random time at night

### DIFF
--- a/roles/unattended_upgrades/defaults/main.yml
+++ b/roles/unattended_upgrades/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 unattended_upgrades_allow_reboot: true
+unattended_upgrades_reboot_immediately: true
 unattended_upgrades_email:
 unattended_upgrades_origins:

--- a/roles/unattended_upgrades/tasks/main.yml
+++ b/roles/unattended_upgrades/tasks/main.yml
@@ -44,6 +44,16 @@
     when: unattended_upgrades_allow_reboot
     tags: unattended_upgrades
 
+  - name: Set random reboot time if update requires it
+    lineinfile:
+      dest: /etc/apt/apt.conf.d/50unattended-upgrades
+      state: present
+      regexp: '^Unattended-Upgrade::Automatic-Reboot-Time '
+      insertafter: '^//Unattended-Upgrade::Automatic-Reboot-Time '
+      line: "Unattended-Upgrade::Automatic-Reboot-Time \"0{{ 5 | random(start=2,seed=inventory_hostname) }}:{{ '%02d' | format((inventory_hostname | hash('md5') | int(0, 16)) % 60 | int) }}\";"
+    when: unattended_upgrades_allow_reboot and not unattended_upgrades_reboot_immediately
+    tags: unattended_upgrades
+
   - name: Send email about unattended upgrades
     lineinfile:
       dest: /etc/apt/apt.conf.d/50unattended-upgrades


### PR DESCRIPTION
If enabled, reboots required by unattended upgrades are set to happen some time between 2:00 and 4:59. Once the configuration is applied, the reboots always happen at the same time, but the time itself differs between different hosts.
Reboot time is random between hosts, but stays the same for each run for the same host (Ansible runs stay idempotent).

By default reboots still occur immediately after the updates requiring them have been applied.