### PR TITLE
Unattended upgrades improvements

### DIFF
--- a/roles/unattended_upgrades/defaults/main.yml
+++ b/roles/unattended_upgrades/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 unattended_upgrades_allow_reboot: true
 unattended_upgrades_reboot_immediately: true
+unattended_upgrades_distro_updates: true
 unattended_upgrades_email:
 unattended_upgrades_from_email:
 unattended_upgrades_origins:

--- a/roles/unattended_upgrades/defaults/main.yml
+++ b/roles/unattended_upgrades/defaults/main.yml
@@ -2,4 +2,5 @@
 unattended_upgrades_allow_reboot: true
 unattended_upgrades_reboot_immediately: true
 unattended_upgrades_email:
+unattended_upgrades_from_email:
 unattended_upgrades_origins:

--- a/roles/unattended_upgrades/defaults/main.yml
+++ b/roles/unattended_upgrades/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 unattended_upgrades_allow_reboot: true
+unattended_upgrades_reboot_immediately: true
 unattended_upgrades_email:
 unattended_upgrades_origins:

--- a/roles/unattended_upgrades/tasks/main.yml
+++ b/roles/unattended_upgrades/tasks/main.yml
@@ -64,6 +64,16 @@
     when: unattended_upgrades_email is not none
     tags: unattended_upgrades
 
+  - name: Set From address for unattended upgrades email notifications
+    lineinfile:
+      dest: /etc/apt/apt.conf.d/50unattended-upgrades
+      state: present
+      regexp: '^Unattended-Upgrade::Sender '
+      insertafter: '^Unattended-Upgrade::Mail '
+      line: 'Unattended-Upgrade::Sender "{{ unattended_upgrades_from_email }}";'
+    when: unattended_upgrades_email is not none and unattended_upgrades_from_email is not none
+    tags: unattended_upgrades
+
   - name: Enable automatic upgrades for distro-updates repository
     lineinfile:
       dest: /etc/apt/apt.conf.d/50unattended-upgrades

--- a/roles/unattended_upgrades/tasks/main.yml
+++ b/roles/unattended_upgrades/tasks/main.yml
@@ -44,6 +44,16 @@
     when: unattended_upgrades_allow_reboot
     tags: unattended_upgrades
 
+  - name: Set random reboot time if update requires it
+    lineinfile:
+      dest: /etc/apt/apt.conf.d/50unattended-upgrades
+      state: present
+      regexp: '^Unattended-Upgrade::Automatic-Reboot-Time '
+      insertafter: '^//Unattended-Upgrade::Automatic-Reboot-Time '
+      line: "Unattended-Upgrade::Automatic-Reboot-Time \"0{{ 5 | random(start=2,seed=inventory_hostname) }}:{{ '%02d' | format((inventory_hostname | hash('md5') | int(0, 16)) % 60 | int) }}\";"
+    when: unattended_upgrades_allow_reboot and not unattended_upgrades_reboot_immediately
+    tags: unattended_upgrades
+
   - name: Send email about unattended upgrades
     lineinfile:
       dest: /etc/apt/apt.conf.d/50unattended-upgrades

--- a/roles/unattended_upgrades/tasks/main.yml
+++ b/roles/unattended_upgrades/tasks/main.yml
@@ -80,7 +80,7 @@
       state: present
       regexp: 'origin=Debian,codename=\${distro_codename}-updates'
       line: '        "origin=Debian,codename=${distro_codename}-updates";'
-    when: unattended_upgrades_email is not none
+    when: unattended_upgrades_distro_updates
     tags: unattended_upgrades
 
   - name: Set custom upgrade origin patterns


### PR DESCRIPTION
### Optionally delay unattended upgrade reboot until some random time at night

If enabled, reboots required by unattended upgrades are set to happen some time between 2:00 and 4:59. Once the configuration is applied, the reboots always happen at the same time, but the time itself differs between different hosts.
Reboot time is random between hosts, but stays the same for each run for the same host (Ansible runs stay idempotent).

By default reboots still occur immediately after the updates requiring them have been applied.

### Allow setting From: address for notification emails

By default the From: value is "root" (without any domain) and some mail provides don't accept it (e.g. SendGrid).

### Use better variable to control distro upgrades for unattended upgrades

Previously this was controlled by `unattended_upgrades_email` variable that makes no sense at all. Introduce a new variable `unattended_upgrades_distro_updates` for this purpose (defaults to `true`).