### PR TITLE
feature: support Node 12 on Rpi Zero

### DIFF
--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
-# For ARMv6 models (A, A+, B, B+, Zero, Zero W). This should match a directory name on the download site: https://nodejs.org/dist/ (e.g. latest-v4.x, v5.8.0, latest)
-nodejs_armv6_version: latest-v12.x   # Latest 12.x series LTS release
+# Node v12 dropped support for ARMv6 models (A, A+, B, B+, Zero, Zero W), use an unofficial build on these architectures.
+# This should match a directory name on the download site: https://unofficial-builds.nodejs.org/download/release/
+nodejs_armv6_version: v12.20.0   # There is no 'latest' directory, this should be updated manually.
+
 # The path to the binary of ARMv6 node installation
 nodejs_armv6_binary: /usr/local/bin/node
 

--- a/roles/node/tasks/armv6_from_nodejs_org.yml
+++ b/roles/node/tasks/armv6_from_nodejs_org.yml
@@ -27,7 +27,7 @@
   failed_when: False
 
 - name: Get latest available Node.js tarball filename
-  shell: curl https://nodejs.org/dist/{{ nodejs_armv6_version }}/ | grep armv6l.tar.gz | sed 's/.*>\(.*\)<\/a>.*/\1/g' || /bin/true
+  shell: curl https://unofficial-builds.nodejs.org/download/release/{{ nodejs_armv6_version }}/ | grep armv6l.tar.gz | sed 's/.*>\(.*\)<\/a>.*/\1/g' || /bin/true
   args:
     warn: False
   register: latest_node_filename
@@ -41,7 +41,7 @@
 - name: Install Node.js
   block:
   - name: Generate download URL
-    set_fact: node_download_url=https://nodejs.org/dist/{{ nodejs_armv6_version }}/node-{{ latest_node_version }}-linux-armv6l.tar.gz
+    set_fact: node_download_url=https://unofficial-builds.nodejs.org/download/release/{{ nodejs_armv6_version }}/node-{{ latest_node_version }}-linux-armv6l.tar.gz
 
   - name: Download Node.js binary distribution
     get_url: url={{ node_download_url }} dest=/tmp/nodejs.tar.gz mode=0440

--- a/roles/signalk-npm/tasks/main.yml
+++ b/roles/signalk-npm/tasks/main.yml
@@ -33,7 +33,10 @@
     poll: 10
     notify: restart-signalk-server
     tags: signalk-npm
-
+  - name: Check if signalk-server file is installed in /usr/bin/ (otherwise it is in /usr/local/bin)
+    stat:
+      path: /usr/bin/signalk-server
+    register: file_in_usr_bin
   - name: "Setup SignalK server systemd service"
     template:
       src: signalk.service.j2
@@ -41,6 +44,8 @@
       owner: root
       group: root
       mode: 0644
+    vars:
+      path_to_signalk_server: "{{ '/usr/bin/signalk-server' if (file_in_usr_bin.stat.exists == True) else '/usr/local/bin/signalk-server' }}"
     notify: restart-signalk-server
     tags: signalk-npm
 

--- a/roles/signalk-npm/templates/signalk.service.j2
+++ b/roles/signalk-npm/templates/signalk.service.j2
@@ -8,7 +8,7 @@ Restart=always
 RestartSec=15s
 User={{ signalk_user }}
 Group={{ signalk_user_group }}
-ExecStart=/usr/bin/signalk-server
+ExecStart={{ path_to_signalk_server }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Node v12 dropped support for ARMv6 models (A, A+, B, B+, Zero, Zero W), use an unofficial build on these architectures.

From #98.