### PR TITLE
Update signalk docker

### DIFF
--- a/roles/signalk-docker/templates/docker-compose.j2
+++ b/roles/signalk-docker/templates/docker-compose.j2
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   signalk:
-    image: "signalk/signalk-server:linux-armhf-master"
+    image: "signalk/signalk-server:master"
     environment:
       EXTERNALHOST: {{ hostname }}
       EXTERNALPORT: 80

--- a/roles/signalk-docker/templates/signalk-docker-compose.service
+++ b/roles/signalk-docker/templates/signalk-docker-compose.service
@@ -13,7 +13,7 @@ ExecStart=/usr/local/bin/docker-compose up -d
 
 ExecStop=/usr/local/bin/docker-compose stop
 
-ExecReload=/usr/local/bin/docker-compose pull --quiet --parallel
+ExecReload=/usr/local/bin/docker-compose pull --quiet
 ExecReload=/usr/local/bin/docker-compose up -d
 
 [Install]


### PR DESCRIPTION
- parallel build is now default, the option is deprecated
- use the multiarch image, direct arm image reference is no longer necessary and should work also with arm64 containers