### PR TITLE
Get Grafana from the official repo

### DIFF
--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -15,12 +15,12 @@
 ---
 - name: Adding APT key
   apt_key:
-    url: https://bintray.com/user/downloadSubjectPublicKey?username=bintray
+    url: https://packages.grafana.com/gpg.key
   become: true
 
 - name: Add APT repository
   apt_repository:
-    repo: "deb https://dl.bintray.com/fg2it/deb jessie main"
+    repo: "deb https://packages.grafana.com/oss/deb stable main"
     update_cache: yes
   become: true
 


### PR DESCRIPTION
The bintray stuff is no longer working. Using the URLs from https://grafana.com/tutorials/install-grafana-on-raspberry-pi/